### PR TITLE
Add Awaiting author contribution

### DIFF
--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -51,6 +51,7 @@
                           repo: context.repo.repo,
                           labels: [label, 'review-requested']
                       })
+                      // TODO: Maybe use GitHub API to request review / assign team
                   }
               }
 

--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -19,7 +19,7 @@
         && !contains(github.event.issue.labels.*.name, 'review-requested')
       runs-on: ubuntu-latest
       steps:
-        - name: add-label
+        - name: add-labels
           uses: actions/github-script@v6
           with:
             debug: true
@@ -52,6 +52,12 @@
                           repo: context.repo.repo,
                           labels: [label, 'review-requested']
                       })
+                      github.rest.issues.removeLabel({
+                          issue_number: context.issue.number,
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          name: ['Awaiting author contribution']
+                      });
                       // TODO: Maybe use GitHub API to request review / assign team
                   }
               }
@@ -71,7 +77,7 @@
         )
       runs-on: ubuntu-latest
       steps:
-        - name: remove-label
+        - name: swap-labels
           uses: actions/github-script@v6
           with:
             debug: true
@@ -89,5 +95,11 @@
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     name: ['review-requested']
+                });
+                github.rest.issues.addLabels({
+                    issue_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    labels: ['Awaiting author contribution']
                 });
               }

--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -3,8 +3,6 @@
   on:
     issue_comment:
       types: [created]
-    pull_request_target:
-      types: [synchronize]
     pull_request_review:
       types: [submitted]
     pull_request_review_comment:
@@ -19,10 +17,9 @@
         github.event.issue
         && github.event.issue.pull_request
         && !contains(github.event.issue.labels.*.name, 'review-requested')
-        && !contains(github.event.issue.labels.*.name, 'Awaiting author contribution')
       runs-on: ubuntu-latest
       steps:
-        - name: team-label
+        - name: add-label
           uses: actions/github-script@v6
           with:
             debug: true
@@ -57,24 +54,22 @@
                   }
               }
 
-    add-awaiting-author-label:
-      name: 'When reviewed, add awaiting author label'
+    remove-review-requested-label:
+      name: 'When reviewed, remove review-requested label'
       if: >
-        ( 
+        (
           github.event.issue
           && github.event.issue.pull_request
           && (github.event.sender.login != github.event.issue.user.login)
           && contains(github.event.issue.labels.*.name, 'review-requested')
-          && !contains(github.event.issue.labels.*.name, 'Awaiting author contribution')
         ) || (
           github.event.pull_request
           && (github.event.sender.login != github.event.pull_request.user.login)
           && contains(github.event.pull_request.labels.*.name, 'review-requested')
-          && !contains(github.event.pull_request.labels.*.name, 'Awaiting author contribution')
         )
       runs-on: ubuntu-latest
       steps:
-        - name: swap-labels
+        - name: remove-label
           uses: actions/github-script@v6
           with:
             debug: true
@@ -93,37 +88,4 @@
                     repo: context.repo.repo,
                     name: ['review-requested']
                 });
-                github.rest.issues.addLabels({
-                    issue_number: context.issue.number,
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    labels: ['Awaiting author contribution']
-                });
               }
-
-    remove-awaiting-author:
-      name: 'When any author action, remove awaiting author label'
-      if: >
-        (
-          github.event.issue
-          && github.event.issue.pull_request
-          && (github.event.sender.login == github.event.issue.user.login)
-          && contains(github.event.issue.labels.*.name, 'Awaiting author contribution')
-        ) || (
-          github.event.pull_request
-          && (github.event.sender.login == github.event.pull_request.user.login)
-          && contains(github.event.pull_request.labels.*.name, 'Awaiting author contribution')
-        )
-      runs-on: ubuntu-latest
-      steps:
-        - name: remove-label
-          uses: actions/github-script@v6
-          with:
-            debug: true
-            script: |
-              github.rest.issues.removeLabel({
-                  issue_number: context.issue.number,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: ['Awaiting author contribution']
-              })

--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -19,6 +19,7 @@
         github.event.issue
         && github.event.issue.pull_request
         && !contains(github.event.issue.labels.*.name, 'review-requested')
+        && !contains(github.event.issue.labels.*.name, 'Awaiting author contribution')
       runs-on: ubuntu-latest
       steps:
         - name: team-label

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ sequenceDiagram
             alt team is in comment
                 GitHub actions->>issue: Adds review-requested label
                 GitHub actions->>issue: Adds team label
+                GitHub actions->>issue: Remove Awaiting author contribution label
                 rect rgb(191, 223, 255)
                     GitHub actions-->>issue: Assigns team for review
                 end
@@ -32,6 +33,7 @@ sequenceDiagram
         Authenticated bot-->>Reviewer: Checks membership
         alt Reviewer is part of staged-recipes
             Authenticated bot->>issue: Remove review-requested label
+            Authenticated bot->>issue: Add Awaiting author contribution label
         end
     end
     deactivate Authenticated bot

--- a/README.md
+++ b/README.md
@@ -12,38 +12,29 @@ sequenceDiagram
     actor Authenticated bot
     actor Reviewer
     Note right of Authenticated bot: Authenticated bot is a GitHub action with the necessary rights for getMembershipForUserInOrg
-    User->>issue: Adds comment with "ping conda-forge/help-python"
+    User->>issue: Adds any comment
     activate GitHub actions
-    Note right of GitHub actions: Triggered file is "add-review-team.yml"
     alt is PR
         loop Over ['@conda-forge/staged-recipes', '@conda-forge/help-python', '@conda-forge/help-python-c', '@conda-forge/help-r', '@conda-forge/help-java', '@conda-forge/help-nodejs', '@conda-forge/help-c-cpp', '@conda-forge/help-perl', '@conda-forge/help-julia', '@conda-forge/help-ruby']
             alt team is in comment
-                GitHub actions->>issue: Add review-requested label
-                GitHub actions->>issue: Add python label
+                GitHub actions->>issue: Adds review-requested label
+                GitHub actions->>issue: Adds team label
                 rect rgb(191, 223, 255)
-                    GitHub actions-->>issue: Assigns help-python team for review
-                end 
-            end 
+                    GitHub actions-->>issue: Assigns team for review
+                end
+            end
         end
     end
     deactivate GitHub actions
-    Reviewer->>issue: Reviews
+    Reviewer->>issue: Adds a review comment
     activate Authenticated bot
-    Note right of Authenticated bot: Triggered file is "add-author-pr.yml" and "add-author-issue_comment.yml".
-    alt Commenter is not author of PR AND review-requested label exists AND is PR AND Awaiting author contribution label does not exist
+    alt is PR AND commenter is not author of PR AND review-requested label exists
         Authenticated bot-->>Reviewer: Checks membership
         alt Reviewer is part of staged-recipes
             Authenticated bot->>issue: Remove review-requested label
-            Authenticated bot->>issue: Add Awaiting author contribution label
-        end 
+        end
     end
     deactivate Authenticated bot
-    Author->>issue: Interacts
-    activate GitHub actions
-    alt Commenter is author of PR AND is PR AND Awaiting author contribution label exists
-        GitHub actions-->>issue: Removes Awaiting author contribution label
-    end
-    deactivate GitHub actions
 ```
 
 _Note_: The blue part is proposed and not actually integrated yet.


### PR DESCRIPTION
I don't see a reason why we shouldn't test for it, do you know one?

Edit: it could be that there author responds and immediately pings the team again but if this is not added the action is triggered quite often. To safe some concurrency, I would rather have that the author needs to comment twice.